### PR TITLE
Update README.md to include libgranite-dev dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you want to hack on and build Principles yourself, you'll need the following 
 * libgtk-3-dev
 * meson
 * valac
+* libgranite-dev
 
 Run `meson build` to configure the build environment and run `ninja test` to build and run automated tests
 


### PR DESCRIPTION
I downloaded Elementary OS Juno, and the first thing I did was download this program to try and learn from it. I kept getting stumped (I think at the compile stage) because I would be prompted in the terminal that I didn't have the "granite" dependency. I'm new to Linux and development in general, so it took me awhile to figure out that "granite" was libgranite-dev and could be installed pretty easily.

Since this app is intended for Elementary OS, and since the dependency is not included in Elementary OS, does it make sense to include this in the README?

Thanks, love your work, it's making it easier to learn.